### PR TITLE
beaglebone.conf: Define policies for libgl* virtual providers

### DIFF
--- a/common-bsp/conf/machine/beaglebone.conf
+++ b/common-bsp/conf/machine/beaglebone.conf
@@ -26,3 +26,10 @@ UBOOT_MACHINE = "am335x_evm_config"
 MACHINE_FEATURES = "kernel26 screen apm usbgadget usbhost vfat alsa"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-devicetree-overlays"
+
+PREFERRED_PROVIDER_virtual/libgl = "mesa-gl"
+PREFERRED_PROVIDER_virtual/egl = "libgles-omap3"
+PREFERRED_PROVIDER_virtual/libgles1 = "libgles-omap3"
+PREFERRED_PROVIDER_virtual/libgles2 = "libgles-omap3"
+PREFERRED_PROVIDER_virtual/mesa = "mesa-gl"
+


### PR DESCRIPTION
Fixes errors like

ERROR: Multiple .bb files are due to be built which each provide
virtual/mesa
(/home/kraj/work/angstrom-repo/sources/openembedded-core/meta/recipes-graphics/mesa/mesa_9.2.2.bb
/home/kraj/work/angstrom-repo/sources/openembedded-core/meta/recipes-graphics/mesa/mesa-gl_9.2.2.bb).

Signed-off-by: Khem Raj raj.khem@gmail.com
