### PR TITLE
u-boot-denx: v2013.10 use correct u-boot include.

### DIFF
--- a/common-bsp/recipes-bsp/u-boot/u-boot-denx_2013.10.bb
+++ b/common-bsp/recipes-bsp/u-boot/u-boot-denx_2013.10.bb
@@ -1,4 +1,4 @@
-require u-boot.inc
+require u-boot-denx.inc
 
 # SPL build
 UBOOT_BINARY = "u-boot.img"


### PR DESCRIPTION
Use u-boot-denx.inc rather than u-boot.inc

Signed-off-by: Dan McGregor dan.mcgregor@usask.ca
