### PR TITLE
recipes-images: Add dropped meta-ti images

### DIFF
--- a/meta-beagleboard-extras/recipes-images/base/ti-hw-bringup-image.bb
+++ b/meta-beagleboard-extras/recipes-images/base/ti-hw-bringup-image.bb
@@ -1,0 +1,32 @@
+# Image for assisting in hardware bringup
+
+include recipes-images/angstrom/systemd-image.bb
+
+EXTRA_MACHINE_IMAGE_INSTALL ?= ""
+
+# Hokey-pokey workaround for MUSB bugs
+EXTRA_MACHINE_IMAGE_INSTALL_ti33x = "gadget-init"
+
+IMAGE_INSTALL += " \
+	usbutils \
+	i2c-tools \
+	alsa-utils \
+	devmem2 \
+	iw \
+	bonnie++ \
+	hdparm \
+	iozone3 \
+	iperf \
+	lmbench \
+	rt-tests \
+	evtest \
+	bc \
+	packagegroup-ti-test \
+	kernel-modules \
+	${EXTRA_MACHINE_IMAGE_INSTALL} \
+"
+
+export IMAGE_BASENAME = "TI-hw-bringup"
+
+# This doesn't work with the current genext2fs in oe-core
+# inherit sdcard_image

--- a/meta-beagleboard-extras/recipes-images/cloud9/cloud9-gfx-image.bb
+++ b/meta-beagleboard-extras/recipes-images/cloud9/cloud9-gfx-image.bb
@@ -1,0 +1,15 @@
+# Image with cloud9 ide, gfx and hw tools installed
+
+require cloud9-image.bb
+
+IMAGE_INSTALL += " \
+                  packagegroup-core-x11-xserver \
+                  angstrom-gnome-icon-theme-enable gtk-engine-clearlooks gtk-theme-clearlooks angstrom-clearlooks-theme-enable \
+                  e-wm-config-default e-wm-config-standard e-wm-config-illume2 \
+                  xserver-nodm-init \
+                  xserver-common \
+                  ttf-dejavu-sans ttf-dejavu-sans-mono ttf-dejavu-common \
+                 "
+
+export IMAGE_BASENAME = "Cloud9-IDE-gfx"
+

--- a/meta-beagleboard-extras/recipes-images/cloud9/cloud9-gnome-image.bb
+++ b/meta-beagleboard-extras/recipes-images/cloud9/cloud9-gnome-image.bb
@@ -1,0 +1,19 @@
+# Image with cloud9 ide, gfx and hw tools installed
+
+require cloud9-image.bb
+
+# SoC specific packages, mostly 3D or multimedia related
+SOCSUPPORT = ""
+SOCSUPPORT_omap3 = "xbmc libgles-omap3-x11demos gstreamer-ti omapfbplay"
+SOCSUPPORT_ti33x = "xbmc libgles-omap3-x11demos gst-ffmpeg mplayer2 beaglebone-capes"
+
+IMAGE_INSTALL += " \
+                  angstrom-packagegroup-gnome gimp abiword gedit midori epiphany firefox matchbox-terminal \
+                  ${SOCSUPPORT} \
+                  ttf-dejavu-sans ttf-dejavu-sans-mono ttf-dejavu-common \
+                  xinput-calibrator \
+                  xterm \
+                 "
+
+export IMAGE_BASENAME = "Cloud9-IDE-GNOME"
+

--- a/meta-beagleboard-extras/recipes-images/cloud9/cloud9-image.bb
+++ b/meta-beagleboard-extras/recipes-images/cloud9/cloud9-image.bb
@@ -1,0 +1,37 @@
+# Image with cloud9 ide and hw tools installed
+
+require ti-hw-bringup-image.bb
+
+FATPAYLOAD = "${datadir}/beaglebone-getting-started/*"
+
+ROOTFSTYPE_beaglebone = "ext4"
+
+IMAGE_INSTALL += " \
+	systemd-analyze \
+	cloud9 \
+	packagegroup-sdk-target \
+	vim vim-vimrc \
+	procps \
+	beaglebone-tester \
+	screen minicom \
+	git \
+	beaglebone-getting-started bonescript \
+	led-config \
+	opencv-dev \
+	cronie-systemd ntpdate \
+	nano \
+	minicom \
+	hicolor-icon-theme \
+	gateone \
+	tar \
+	gdb gdbserver \
+	nodejs-dev \
+	mplayer2 \
+	tslib-tests tslib-calibrate \
+	iproute2 canutils \
+	connman-tests \
+	rsync \
+"
+
+export IMAGE_BASENAME = "Cloud9-IDE"
+


### PR DESCRIPTION
As requested (and rightly so), move cloud9-*-image.bb into recipes-images/cloud9 and ti-hw-bringup-image.bb into recipes-images/base
