### PR TITLE
gadget-init: Update license checksum

### DIFF
--- a/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init.bb
+++ b/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Units to initialize usb gadgets"
 inherit systemd
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
 
 COMPATIBLE_MACHINE = "(beaglebone)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
FIxes LIC_FILES_CHKSUM errors seen with latest OE-Core/master

Signed-off-by: Khem Raj raj.khem@gmail.com
