### PR TITLE
xserver-xf86-config: Use FILESEXTRAPATHS for adding search dirs for F…

### DIFF
--- a/common-bsp/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/common-bsp/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -1,3 +1,1 @@
-THISDIR := "${@os.path.dirname(bb.data.getVar('FILE', d, True))}"
-FILESPATH =. "${@base_set_filespath(["${THISDIR}/${PN}"], d)}:"
-
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
…ILESPATH

Setting THISDIR in this fashion is creating problems in mutli BSP env
lets use simple FILESEXTRAPATHS mechanism

Signed-off-by: Khem Raj <raj.khem@gmail.com>