### PR TITLE
device-tree-overlays: Device Tree Overlays for bb.org boards

### DIFF
--- a/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
+++ b/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
@@ -7,7 +7,7 @@ COMPATIBLE_MACHINE = "(beaglebone)"
 
 PV = "1.0+git${SRCPV}"
 
-DEPENDS_${PN} = "dtc"
+DEPENDS = "dtc-native"
 
 SRC_URI = "git://github.com/beagleboard/bb.org-overlays.git;branch=master;nobranch=1"
 SRCREV_pn-${PN} = "25cf610eda61a323048bd46a458fe8bf6d1c6af5"

--- a/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
+++ b/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Device Tree Overlays for bb.org boards"
 
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
 COMPATIBLE_MACHINE = "(beaglebone)"
 
@@ -13,10 +13,6 @@ SRC_URI = "git://github.com/beagleboard/bb.org-overlays.git;branch=master;nobran
 SRCREV_pn-${PN} = "25cf610eda61a323048bd46a458fe8bf6d1c6af5"
 
 S = "${WORKDIR}/git"
-
-do_configure() {
-	:
-}
 
 do_compile() {
 	oe_runmake DTC=dtc

--- a/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
+++ b/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "Device Tree Overlays for bb.org boards"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+
+COMPATIBLE_MACHINE = "(beaglebone)"
+
+PV = "1.0+git${SRCPV}"
+PR = "r1"
+
+DEPENDS_${PN} = "dtc"
+
+SRC_URI = "git://github.com/beagleboard/bb.org-overlays.git;branch=master;nobranch=1"
+SRCREV_pn-${PN} = "25cf610eda61a323048bd46a458fe8bf6d1c6af5"
+
+S = "${WORKDIR}/git"
+
+do_configure() {
+	:
+}
+
+do_compile() {
+	oe_runmake DTC=dtc
+}
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+}
+
+
+FILES_${PN} = " \
+	/lib/firmware \
+"

--- a/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
+++ b/common-bsp/recipes-kernel/device-tree-overlays/device-tree-overlays_git.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d
 COMPATIBLE_MACHINE = "(beaglebone)"
 
 PV = "1.0+git${SRCPV}"
-PR = "r1"
 
 DEPENDS_${PN} = "dtc"
 


### PR DESCRIPTION
linux-beagleboard 4.1 no longer includes device tree overlays (dtbo) for bb.org supported capes as those have been moved to a separate upstream repository.

This recipe builds device tree overlays available from https://github.com/beagleboard/bb.org-overlays