### PR TITLE
machines: Add LAYERSERIES_COMPAT variable to layer.conf

### DIFF
--- a/common-bsp/conf/layer.conf
+++ b/common-bsp/conf/layer.conf
@@ -7,3 +7,5 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "meta-beagleboard-common"
 BBFILE_PATTERN_meta-beagleboard-common := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-beagleboard-common = "8"
+
+LAYERSERIES_COMPAT_meta-beagleboard-common = "thud"


### PR DESCRIPTION
Fix warning issued by OpenEmbedded:
```WARNING: Layer meta-beagleboard-common should set LAYERSERIES_COMPAT_meta-beagleboard-common in its conf/layer.conf file to list the core layer names it is compatible with.```
